### PR TITLE
added item index to questionnaire response validation error message

### DIFF
--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -11,6 +11,7 @@
 
 	<artifactId>hapi-fhir-structures-dstu3</artifactId>
 	<packaging>jar</packaging>
+	<version>2.4.20180809</version>
 
 	<name>HAPI FHIR Structures - DSTU3</name>
 
@@ -18,12 +19,12 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
-			<version>${project.version}</version>
+			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-dstu3</artifactId>
-			<version>${project.version}</version>
+			<version>2.4</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/validation/InstanceValidator.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/validation/InstanceValidator.java
@@ -2424,7 +2424,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     if (elements.size() > 1)
       rule(errors, IssueType.INVALID, elements.get(1).line(), elements.get(1).col(), stack.getLiteralPath(), qItem.getRepeats(), "Only one response item with this linkId allowed");
     for (Element element : elements) {
-      NodeStack ns = stack.push(element, -1, null, null);
+      NodeStack ns = stack.push(element, element.getIndex()+1, null, null);
       validateQuestionannaireResponseItem(qsrc, qItem, errors, element, ns, inProgress);
     }
   }
@@ -2451,7 +2451,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
           QuestionnaireItemComponent qItem = findQuestionnaireItem(qsrc, linkId);
           if (qItem != null) {
             rule(errors, IssueType.STRUCTURE, item.line(), item.col(), stack.getLiteralPath(), index > -1, "Structural Error: item is in the wrong place");
-            NodeStack ns = stack.push(item, -1, null, null);
+            NodeStack ns = stack.push(item, element.getIndex()+1, null, null);
             validateQuestionannaireResponseItem(qsrc, qItem, errors, element, ns, inProgress);
           }
           else
@@ -2532,7 +2532,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 	  rule(errors, IssueType.STRUCTURE, value.line(), value.col(), stack.getLiteralPath(), found, "The code "+system+"::"+code+" is not a valid option");
 	}*/
 
-  private void validateAnswerCode(List<ValidationMessage> errors, Element value, NodeStack stack, Questionnaire qSrc, Reference ref, boolean theOpenChoice) {
+  private void validateAnswerCode(List<ValidationMessage> errors, Element value, NodeStack stack, Questionnaire qSrc, String linkId, Reference ref, boolean theOpenChoice) {
     ValueSet vs = resolveBindingReference(qSrc, ref, qSrc.getUrl());
     if (warning(errors, IssueType.CODEINVALID, value.line(), value.col(), stack.getLiteralPath(), vs != null, "ValueSet " + describeReference(ref) + " not found"))  {
       try {
@@ -2547,7 +2547,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
         ValidationResult res = context.validateCode(c, vs);
         txTime = txTime + (System.nanoTime() - t);
         if (!res.isOk())
-          rule(errors, IssueType.CODEINVALID, value.line(), value.col(), stack.getLiteralPath(), false, "The value provided ("+c.getSystem()+"::"+c.getCode()+") is not in the options value set in the questionnaire");
+          rule(errors, IssueType.CODEINVALID, value.line(), value.col(), stack.getLiteralPath(), false, "The value provided ("+(c.getSystem()==null?"":c.getSystem()+"::")+c.getCode()+") for '" + linkId + "' is not in the options value set in the questionnaire");
       } catch (Exception e) {
         warning(errors, IssueType.CODEINVALID, value.line(), value.col(), stack.getLiteralPath(), false, "Error " + e.getMessage() + " validating Coding against Questionnaire Options");
       }
@@ -2561,7 +2561,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       checkCodingOption(errors, answer, stack, qSrc, qItem, theOpenChoice);
     //	    validateAnswerCode(errors, v, stack, qItem.getOption());
     else if (qItem.hasOptions())
-      validateAnswerCode(errors, v, stack, qSrc, qItem.getOptions(), theOpenChoice);
+      validateAnswerCode(errors, v, stack, qSrc, qItem.getLinkId(), qItem.getOptions(), theOpenChoice);
     else
       hint(errors, IssueType.STRUCTURE, v.line(), v.col(), stack.getLiteralPath(), false, "Cannot validate options because no option or options are provided");
   }

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/validation/QuestionnaireResponseValidatorDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/validation/QuestionnaireResponseValidatorDstu3Test.java
@@ -146,8 +146,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		errors = stripBindingHasNoSourceMessage(errors);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system::code1) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system::code1) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		qa = new QuestionnaireResponse();
 		qa.setStatus(QuestionnaireResponseStatus.COMPLETED);
@@ -156,8 +156,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		errors = stripBindingHasNoSourceMessage(errors);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system2::code3) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system2::code3) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 	}
 
@@ -271,8 +271,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		errors = stripBindingHasNoSourceMessage(errors);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system::code1) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (http://codesystems.com/system::code1) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		// Partial code
 
@@ -283,8 +283,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		errors = stripBindingHasNoSourceMessage(errors);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (null::code1) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (code1) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		qa = new QuestionnaireResponse();
 		qa.setStatus(QuestionnaireResponseStatus.COMPLETED);
@@ -293,8 +293,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		errors = stripBindingHasNoSourceMessage(errors);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (null::code1) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (code1) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		qa = new QuestionnaireResponse();
 		qa.setStatus(QuestionnaireResponseStatus.COMPLETED);
@@ -302,8 +302,8 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		qa.addItem().setLinkId("link0").addAnswer().setValue(new Coding().setSystem("http://system").setCode(null));
 		errors = myVal.validateWithResult(qa);
 		ourLog.info(errors.toString());
-		assertThat(errors.toString(), containsString("The value provided (http://system::null) is not in the options value set in the questionnaire"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("The value provided (http://system::null) for 'link0' is not in the options value set in the questionnaire"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		// Wrong type
 
@@ -314,7 +314,7 @@ public class QuestionnaireResponseValidatorDstu3Test {
 		errors = myVal.validateWithResult(qa);
 		ourLog.info(errors.toString());
 		assertThat(errors.toString(), containsString("Cannot validate integer answer option because no option list is provided"));
-		assertThat(errors.toString(), containsString("QuestionnaireResponse.item.answer"));
+		assertThat(errors.toString(), containsString("QuestionnaireResponse.item[1].answer"));
 
 		// String answer
 


### PR DESCRIPTION
This is for version 2.4

- added item index to the structural error location for questionnaireResponse items so that users can easily identify which questionnaire item causes the validation error; 
- added item linkId to the output message for questionnaireResponse item valueset error so that users can easily identify which questionnaire item causes the validation error; 
- removed naming system string in submitted value from output error message if it is null.
